### PR TITLE
Add SQL schema

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,51 @@
+-- SQL schema for CHARIO database
+-- This file creates patients, drivers, rides, and payments tables with UUID primary keys
+-- and appropriate foreign key relationships. It also includes indexes for ride pickup time
+-- and status.
+
+-- Enable extension for generating UUIDs if not already enabled.
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Patients table
+CREATE TABLE patients (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Drivers table
+CREATE TABLE drivers (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Payments table
+CREATE TABLE payments (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    amount NUMERIC(10,2) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Enum type for ride status
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'ride_status') THEN
+        CREATE TYPE ride_status AS ENUM ('pending', 'confirmed', 'completed');
+    END IF;
+END $$;
+
+-- Rides table linking patients and drivers
+CREATE TABLE rides (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    patient_id UUID REFERENCES patients(id) ON DELETE SET NULL,
+    driver_id UUID REFERENCES drivers(id) ON DELETE SET NULL,
+    pickup_time TIMESTAMPTZ NOT NULL,
+    status ride_status NOT NULL DEFAULT 'pending',
+    insurance_id UUID NULL,
+    stripe_payment_id UUID REFERENCES payments(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for queries on pickup_time and status
+CREATE INDEX idx_rides_pickup_time ON rides(pickup_time);
+CREATE INDEX idx_rides_status ON rides(status);


### PR DESCRIPTION
## Summary
- add SQL schema to create patients, drivers, rides and payments tables
- include ride status enum, foreign-key constraints, and indexes

## Testing
- `cat schema.sql`

------
https://chatgpt.com/codex/tasks/task_e_684a341a77f48326967d200db1938c5d