### PR TITLE
Add seed script for patients, drivers, and rides

### DIFF
--- a/seed.js
+++ b/seed.js
@@ -1,0 +1,45 @@
+const { Client } = require('pg');
+
+const client = new Client({
+  connectionString: process.env.DATABASE_URL,
+});
+
+async function seed() {
+  await client.connect();
+  try {
+    // Insert patients
+    for (let i = 1; i <= 5; i++) {
+      await client.query(
+        'INSERT INTO patients (name, phone) VALUES ($1, $2)',
+        [`Patient ${i}`, `555-000${i}`]
+      );
+    }
+
+    // Insert drivers
+    for (let i = 1; i <= 3; i++) {
+      await client.query(
+        'INSERT INTO drivers (name, phone) VALUES ($1, $2)',
+        [`Driver ${i}`, `555-100${i}`]
+      );
+    }
+
+    // Insert rides
+    for (let i = 1; i <= 3; i++) {
+      const patientId = i; // simple mapping
+      const driverId = i; // simple mapping
+      const scheduled = new Date(Date.now() + i * 86400000); // i days from now
+      await client.query(
+        'INSERT INTO rides (patient_id, driver_id, scheduled_time, status) VALUES ($1, $2, $3, $4)',
+        [patientId, driverId, scheduled, 'pending']
+      );
+    }
+
+    console.log('Seed data inserted successfully.');
+  } catch (err) {
+    console.error('Error inserting seed data:', err);
+  } finally {
+    await client.end();
+  }
+}
+
+seed();


### PR DESCRIPTION
## Summary
- create Node.js script `seed.js` that uses `pg` to add sample patients, drivers, and rides

## Testing
- `node --version`
- `DATABASE_URL=postgres://user:pass@localhost:5432/db node seed.js` *(fails: Cannot find module 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_684a343eab148326a59ef50a316f9c69