### PR TITLE
Fix missing dotenv setup

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,13 @@
+# Sample environment configuration for CHARIO
+# Copy this file to .env and fill in real credentials
+DATABASE_URL=postgres://user:pass@localhost:5432/chario
+JWT_SECRET=changeme
+STRIPE_SECRET_KEY=sk_test_yourkey
+TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_AUTH_TOKEN=your_auth_token
+TWILIO_FROM_PHONE=+11234567890
+S3_BUCKET=chario-dev
+S3_ENDPOINT=http://localhost:9000
+S3_ACCESS_KEY=minio
+S3_SECRET_KEY=minio123
+PORT=3000

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This boots Postgres, Redis, MinIO and the API server with sample configuration.
 | `S3_SECRET_KEY` | Secret key for S3/MinIO |
 | `PORT` | API HTTP port |
 
+A `.env.sample` file in the repository lists these variables with placeholder
+values. Copy it to `.env` and update the credentials for local development.
+
 ## API endpoints
 
 | Method & Path | Description |

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "aws-sdk": "^2.1692.0",
+        "dotenv": "^16.4.1",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
         "node-cron": "^3.0.2",
@@ -2279,6 +2280,18 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "stripe": "^12.0.0",
     "twilio": "^4.16.0",
     "node-cron": "^3.0.2",
-    "socket.io": "^4.7.2"
+    "socket.io": "^4.7.2",
+    "dotenv": "^16.4.1"
   },
   "devDependencies": {
     "jest": "^29.6.1",


### PR DESCRIPTION
## Summary
- include dotenv in dependencies
- provide a `.env.sample` file and mention it in README

## Testing
- `npm run lint`
- `npm test`
- `npm audit`
- `node index.js`

------
https://chatgpt.com/codex/tasks/task_e_684a462495f08326b9ccb300f8e308c0