### PR TITLE
Require patient authentication for ride creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ values. Copy it to `.env` and update the credentials for local development.
 
 | Method & Path | Description |
 | --- | --- |
-| `POST /rides` | Create a ride request |
+| `POST /rides` | Authenticated patients create a ride request |
 | `GET /rides` | List rides (filter by status, driver or patient) |
 | `PUT /rides/:id/assign` | Assign the authenticated driver to a ride |
 | `PUT /rides/:id/complete` | Mark a ride complete and trigger payout |

--- a/__mocks__/pg.js
+++ b/__mocks__/pg.js
@@ -6,10 +6,11 @@ class Pool {
     if (sql.startsWith('INSERT INTO rides')) {
       const ride = {
         id: rides.length + 1,
-        pickup_time: params[0],
-        pickup_address: params[1],
-        dropoff_address: params[2],
-        payment_type: params[3],
+        patient_id: params[0],
+        pickup_time: params[1],
+        pickup_address: params[2],
+        dropoff_address: params[3],
+        payment_type: params[4],
         status: 'pending'
       };
       rides.push(ride);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,6 +38,7 @@ Key indexes exist on `rides.pickup_time` and `rides.status`.
 ## Request/response examples
 
 ### Create a ride
+Requires a JWT for a patient user in the `Authorization` header.
 
 Request:
 ```bash

--- a/server/src/rides/rides.test.js
+++ b/server/src/rides/rides.test.js
@@ -2,6 +2,7 @@ jest.mock('pg');
 
 const request = require('supertest');
 const { app, pool } = require('../app');
+const { issueToken } = require('../auth');
 const { __rides } = require('pg');
 
 describe('/rides booking endpoint', () => {
@@ -9,10 +10,13 @@ describe('/rides booking endpoint', () => {
     __rides.length = 0;
   });
 
+  const auth = `Bearer ${issueToken({ id: 'patient-1', role: 'patient' })}`;
+
   test('valid booking returns 201', async () => {
     const future = new Date(Date.now() + 8 * 24 * 60 * 60 * 1000).toISOString();
     const res = await request(app)
       .post('/rides')
+      .set('authorization', auth)
       .send({
         pickup_time: future,
         pickup_address: 'A',
@@ -26,6 +30,7 @@ describe('/rides booking endpoint', () => {
     const soon = new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString();
     const res = await request(app)
       .post('/rides')
+      .set('authorization', auth)
       .send({
         pickup_time: soon,
         pickup_address: 'A',
@@ -42,6 +47,7 @@ describe('/rides booking endpoint', () => {
 
     await request(app)
       .post('/rides')
+      .set('authorization', auth)
       .send({
         pickup_time: future,
         pickup_address: 'A',


### PR DESCRIPTION
## Summary
- enforce patient auth on POST /rides endpoint
- store patient_id on ride creation and update mock database
- update API docs to mention auth requirement
- adjust unit tests for auth

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a495b2d848326b8674b52935db74e