### PR TITLE
Add tests for error branches

### DIFF
--- a/server/src/insurance/__tests__/insurance.test.js
+++ b/server/src/insurance/__tests__/insurance.test.js
@@ -21,4 +21,19 @@ describe('uploadInsurance', () => {
     expect(__insuranceDocs.length).toBe(1);
     expect(__insuranceDocs[0]).toEqual({ ride_id: 1, s3_key: 'f.txt' });
   });
+
+  test('missing S3_BUCKET throws error', async () => {
+    delete process.env.S3_BUCKET;
+    await expect(uploadInsurance(Buffer.from('b'), 'f.txt', 1))
+      .rejects.toThrow('S3_BUCKET env var required');
+    process.env.S3_BUCKET = 'bucket';
+  });
+
+  test('upload failure propagates error', async () => {
+    const AWS = require('aws-sdk');
+    const instance = AWS.S3.mock.results[0].value;
+    instance.upload.mockImplementation(() => ({ promise: jest.fn().mockRejectedValue(new Error('fail')) }));
+    await expect(uploadInsurance(Buffer.from('b'), 'f.txt', 1))
+      .rejects.toThrow('fail');
+  });
 });

--- a/server/src/payments/__tests__/payments.test.js
+++ b/server/src/payments/__tests__/payments.test.js
@@ -18,4 +18,17 @@ describe('chargeCard', () => {
     expect(ride.stripe_payment_id).toBe('pi_1');
     expect(ride.status).toBe('confirmed');
   });
+
+  test('missing parameters throw error', async () => {
+    await expect(chargeCard({ amount: 10, customerId: 'c' }))
+      .rejects.toThrow('rideId, amount, and customerId are required');
+  });
+
+  test('stripe errors propagate', async () => {
+    const stripeFactory = require('stripe');
+    const stripeInstance = stripeFactory.mock.results[0].value;
+    stripeInstance.paymentIntents.create.mockRejectedValueOnce(new Error('bad'));
+    await expect(chargeCard({ rideId: 1, amount: 10, customerId: 'cus_1' }))
+      .rejects.toThrow('bad');
+  });
 });

--- a/server/src/rides/rides.test.js
+++ b/server/src/rides/rides.test.js
@@ -54,4 +54,26 @@ describe('/rides booking endpoint', () => {
 
     expect(after).toBe(before + 1);
   });
+
+  test('missing fields return 400', async () => {
+    const future = new Date(Date.now() + 8 * 24 * 60 * 60 * 1000).toISOString();
+    const res = await request(app)
+      .post('/rides')
+      .send({ pickup_time: future, dropoff_address: 'B', payment_type: 'card' });
+    expect(res.status).toBe(400);
+  });
+
+  test('database errors return 500', async () => {
+    const future = new Date(Date.now() + 8 * 24 * 60 * 60 * 1000).toISOString();
+    jest.spyOn(pool, 'query').mockRejectedValueOnce(new Error('db fail'));
+    const res = await request(app)
+      .post('/rides')
+      .send({
+        pickup_time: future,
+        pickup_address: 'A',
+        dropoff_address: 'B',
+        payment_type: 'card'
+      });
+    expect(res.status).toBe(500);
+  });
 });


### PR DESCRIPTION
## Summary
- expand payments unit tests for missing args & Stripe failures
- cover insurance upload failures
- handle invalid bookings and DB failures

## Testing
- `npm test`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_684a4ecc78ec8326be32040ec34da2ab