### PR TITLE
Improve Docker setup and env management

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+coverage
+__tests__
+__mocks__
+*.log
+npm-debug.log*

--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 # Sample environment configuration for CHARIO
 # Copy this file to .env and fill in real credentials
-DATABASE_URL=postgres://user:pass@localhost:5432/chario
+DATABASE_URL=postgres://chario:chario@postgres:5432/chario
 JWT_SECRET=changeme
 STRIPE_SECRET_KEY=sk_test_yourkey
 TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
@@ -11,3 +11,8 @@ S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minio
 S3_SECRET_KEY=minio123
 PORT=3000
+POSTGRES_DB=chario
+POSTGRES_USER=chario
+POSTGRES_PASSWORD=chario
+MINIO_ROOT_USER=minio
+MINIO_ROOT_PASSWORD=minio123

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,17 @@
-FROM node:18-alpine
+# Stage 1: install dependencies
+FROM node:20-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --omit=dev
+
+# Stage 2: copy source and node modules to slim runtime
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+RUN apk add --no-cache curl
+COPY --from=builder /app/node_modules ./node_modules
 COPY . .
 EXPOSE 3000
 CMD ["sh", "-c", "npm run migrate && npm run seed && node index.js"]
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,17 @@
 version: '3.8'
 services:
   api:
-    image: node:18
-    working_dir: /usr/src/app
-    volumes:
-      - ./:/usr/src/app
-    command: sh -c "npm install && npm start"
+    build: .
+    env_file:
+      - .env
     environment:
-      POSTGRES_DB: chario
-      POSTGRES_USER: chario
-      POSTGRES_PASSWORD: chario
       PGHOST: postgres
-      DATABASE_URL: postgres://chario:chario@postgres:5432/chario
       REDIS_URL: redis://redis:6379
-      S3_ENDPOINT: http://minio:9000
-      S3_ACCESS_KEY: minio
-      S3_SECRET_KEY: minio123
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     depends_on:
       postgres:
         condition: service_healthy
@@ -28,10 +24,12 @@ services:
 
   postgres:
     image: postgres:14-alpine
+    env_file:
+      - .env
     environment:
-      POSTGRES_DB: chario
-      POSTGRES_USER: chario
-      POSTGRES_PASSWORD: chario
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - db-data:/var/lib/postgresql/data
     healthcheck:
@@ -52,9 +50,11 @@ services:
   minio:
     image: minio/minio
     command: server /data
+    env_file:
+      - .env
     environment:
-      MINIO_ROOT_USER: minio
-      MINIO_ROOT_PASSWORD: minio123
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
     volumes:
       - minio-data:/data
     ports:

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -28,6 +28,9 @@ app.use(helmet());
 app.use(limiter);
 app.use(express.static('public'));
 
+// Simple health endpoint for containers
+app.get('/healthz', (req, res) => res.send('ok'));
+
 const rideSchema = Joi.object({
   pickup_time: Joi.string().isoDate().required(),
   pickup_address: Joi.string().required(),


### PR DESCRIPTION
## Summary
- use multi-stage build for smaller image
- add curl for container healthcheck
- declare health endpoint in server
- share secrets via `.env` and compose `env_file`
- add `.dockerignore`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a50ed220c832686d7e6a0d2242339