### PR TITLE
Fix deprecated artifact action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Test with coverage
         run: npm run test:ci
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: |

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -16,7 +16,7 @@ jobs:
           path: '.'
           format: 'HTML'
       - name: Upload report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dependency-check-report
           path: ./reports


### PR DESCRIPTION
## Summary
- fix failing CI by using actions/upload-artifact@v4

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a5c75e39c8326bc85d882b6464b2f