### PR TITLE
Fix dependency-check action version

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run OWASP Dependency Check
-        uses: dependency-check/Dependency-Check_Action@v3.0.2
+        uses: dependency-check/Dependency-Check_Action@v3.0.3
         with:
           project: 'CHARIO'
           path: '.'


### PR DESCRIPTION
## Summary
- fix the dependency-check workflow to use v3.0.3 instead of the missing v3.0.2

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a5d8eeba0832682dff40da671cdd7