### PR TITLE
Fix dependency-check action version

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run OWASP Dependency Check
-        uses: dependency-check/Dependency-Check_Action@v3.0.3
+        uses: dependency-check/Dependency-Check_Action@1.1.0
         with:
           project: 'CHARIO'
           path: '.'


### PR DESCRIPTION
## Summary
- use valid version for dependency-check action

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a5edc2f34832689ac64e9811b5fc3