### PR TITLE
Centralized env config

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-require('dotenv').config();
+const { config } = require('./src/config/env');
 const { server, scheduleReminders } = require('./server/src/app');
 
-const port = process.env.PORT || 3000;
+const port = config.PORT || 3000;
 
 scheduleReminders();
 server.listen(port, () => console.log(`Server running on port ${port}`));

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,6 +1,8 @@
+const { config } = require('./src/config/env');
+
 module.exports = {
   client: 'pg',
-  connection: process.env.DATABASE_URL,
+  connection: config.DATABASE_URL,
   migrations: {
     tableName: 'knex_migrations',
     directory: './migrations'

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "prom-client": "^15.1.3",
         "socket.io": "^4.7.2",
         "stripe": "^12.0.0",
-        "twilio": "^4.16.0"
+        "twilio": "^4.16.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "eslint": "^9.28.0",
@@ -6938,6 +6939,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.62",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.62.tgz",
+      "integrity": "sha512-YCxsr4DmhPcrKPC9R1oBHQNlQzlJEyPAId//qTau/vBee9uO8K6prmRq4eMkOyxvBfH4wDPIPdLx9HVMWIY3xA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "prom-client": "^15.1.3",
     "socket.io": "^4.7.2",
     "stripe": "^12.0.0",
-    "twilio": "^4.16.0"
+    "twilio": "^4.16.0",
+    "zod": "^3.23.8"
   },
   "overrides": {
     "debug": "^4.4.1"

--- a/seed.js
+++ b/seed.js
@@ -1,7 +1,9 @@
 const { Client } = require('pg');
 
+const { config } = require('./src/config/env');
+
 const client = new Client({
-  connectionString: process.env.DATABASE_URL,
+  connectionString: config.DATABASE_URL,
 });
 
 async function seed() {

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -6,7 +6,8 @@ const pinoHttp = require('pino-http');
 const { randomUUID } = require('crypto');
 const { observeRequest, metricsEndpoint } = require('./metrics');
 let pool;
-const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY || '');
+const { config } = require('../../src/config/env');
+const stripe = require('stripe')(config.STRIPE_KEY || '');
 const { payoutDriver } = require('./payments/payouts');
 const { authenticate } = require('./auth');
 const { sendSMS } = require('./rides/sms');
@@ -22,7 +23,7 @@ const logger = pinoHttp({
 });
 const limiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 100 });
 function requireTLS(req, res, next) {
-  if (process.env.NODE_ENV === 'test') {
+  if (config.NODE_ENV === 'test') {
     return next();
   }
   if (req.secure || req.headers['x-forwarded-proto'] === 'https') {
@@ -43,7 +44,7 @@ app.post(
   express.raw({ type: 'application/json' }),
   async (req, res) => {
     const sig = req.header('stripe-signature');
-    const secret = process.env.STRIPE_WEBHOOK_SECRET;
+    const secret = config.STRIPE_WEBHOOK_SECRET;
     let event;
     try {
       event = stripe.webhooks.constructEvent(req.body, sig, secret);

--- a/server/src/auth/__tests__/auth.test.js
+++ b/server/src/auth/__tests__/auth.test.js
@@ -1,3 +1,9 @@
+process.env.DATABASE_URL = 'postgres://test';
+process.env.JWT_SECRET = 'secret';
+process.env.STRIPE_KEY = 'sk';
+process.env.TWILIO_SID = 'sid';
+process.env.TWILIO_TOKEN = 'token';
+process.env.S3_BUCKET = 'bucket';
 const { authenticate, issueToken } = require('../index');
 
 describe('auth module', () => {

--- a/server/src/auth/index.js
+++ b/server/src/auth/index.js
@@ -1,6 +1,7 @@
 const jwt = require('jsonwebtoken');
 
-const SECRET = process.env.JWT_SECRET || 'changeme';
+const { config } = require('../../../src/config/env');
+const SECRET = config.JWT_SECRET;
 
 function authenticate(req, res, next) {
   const authHeader = req.header('authorization');

--- a/server/src/insurance/__tests__/insurance.test.js
+++ b/server/src/insurance/__tests__/insurance.test.js
@@ -5,35 +5,44 @@ jest.mock('aws-sdk', () => {
   })) };
 });
 
-const { __insuranceDocs } = require('pg');
-const uploadInsurance = require('../index');
-
-process.env.S3_BUCKET = 'bucket';
+let uploadInsurance;
+let __insuranceDocs;
 
 describe('uploadInsurance', () => {
   beforeEach(() => {
+    jest.resetModules();
+    process.env.DATABASE_URL = 'postgres://test';
+    process.env.JWT_SECRET = 'secret';
+    process.env.STRIPE_KEY = 'sk';
+    process.env.TWILIO_SID = 'sid';
+    process.env.TWILIO_TOKEN = 'token';
+    process.env.S3_BUCKET = 'bucket';
+    ({ __insuranceDocs } = require('pg'));
+    uploadInsurance = require('../index');
     __insuranceDocs.length = 0;
   });
 
-  test('uploads file to s3 and records doc', async () => {
+test('uploads file to s3 and records doc', async () => {
     const url = await uploadInsurance(Buffer.from('buf'), 'f.txt', 1);
     expect(url).toBe('http://signed-url');
     expect(__insuranceDocs.length).toBe(1);
     expect(__insuranceDocs[0]).toEqual({ ride_id: 1, s3_key: 'f.txt' });
   });
 
-  test('missing S3_BUCKET throws error', async () => {
+test('missing S3_BUCKET throws error', () => {
     delete process.env.S3_BUCKET;
-    await expect(uploadInsurance(Buffer.from('b'), 'f.txt', 1))
-      .rejects.toThrow('S3_BUCKET env var required');
+    jest.resetModules();
+    expect(() => {
+      require('../index');
+    }).toThrow('Missing required env vars: S3_BUCKET');
     process.env.S3_BUCKET = 'bucket';
   });
 
-  test('upload failure propagates error', async () => {
+test('upload failure propagates error', async () => {
     const AWS = require('aws-sdk');
     const instance = AWS.S3.mock.results[0].value;
     instance.upload.mockImplementation(() => ({ promise: jest.fn().mockRejectedValue(new Error('fail')) }));
     await expect(uploadInsurance(Buffer.from('b'), 'f.txt', 1))
       .rejects.toThrow('fail');
-  });
+});
 });

--- a/server/src/insurance/index.js
+++ b/server/src/insurance/index.js
@@ -2,6 +2,7 @@ const AWS = require('aws-sdk');
 const { Pool } = require('pg');
 const { Readable } = require('stream');
 
+const { config } = require('../../../src/config/env');
 const s3 = new AWS.S3();
 const pool = new Pool();
 
@@ -13,7 +14,7 @@ const pool = new Pool();
  * @returns {Promise<string>} pre-signed download URL
  */
 async function uploadInsurance(fileBuffer, fileName, rideId) {
-  const bucket = process.env.S3_BUCKET;
+  const bucket = config.S3_BUCKET;
   if (!bucket) throw new Error('S3_BUCKET env var required');
 
   const stream = Readable.from(fileBuffer);

--- a/server/src/payments/__tests__/payments.test.js
+++ b/server/src/payments/__tests__/payments.test.js
@@ -2,6 +2,13 @@ jest.mock('stripe', () => jest.fn(() => ({
   paymentIntents: { create: jest.fn().mockResolvedValue({ id: 'pi_1' }) }
 })));
 
+process.env.DATABASE_URL = 'postgres://test';
+process.env.JWT_SECRET = 'secret';
+process.env.STRIPE_KEY = 'sk';
+process.env.TWILIO_SID = 'sid';
+process.env.TWILIO_TOKEN = 'token';
+process.env.S3_BUCKET = 'bucket';
+
 const { Pool, __rides } = require('pg');
 const { chargeCard } = require('../index');
 

--- a/server/src/payments/__tests__/webhook.test.js
+++ b/server/src/payments/__tests__/webhook.test.js
@@ -2,6 +2,13 @@ jest.mock('pg');
 
 const request = require('supertest');
 const stripe = require('stripe')('sk_test');
+process.env.DATABASE_URL = 'postgres://test';
+process.env.JWT_SECRET = 'secret';
+process.env.STRIPE_KEY = 'sk';
+process.env.TWILIO_SID = 'sid';
+process.env.TWILIO_TOKEN = 'token';
+process.env.S3_BUCKET = 'bucket';
+process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test';
 const { app, io } = require('../../app');
 const { __rides } = require('pg');
 

--- a/server/src/payments/index.js
+++ b/server/src/payments/index.js
@@ -1,4 +1,5 @@
-const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
+const { config } = require('../../../src/config/env');
+const stripe = require('stripe')(config.STRIPE_KEY);
 const { Pool } = require('pg');
 
 const pool = new Pool();

--- a/server/src/rides/__tests__/complete.test.js
+++ b/server/src/rides/__tests__/complete.test.js
@@ -1,6 +1,13 @@
 const request = require('supertest');
 jest.mock('pg');
 
+process.env.DATABASE_URL = 'postgres://test';
+process.env.JWT_SECRET = 'secret';
+process.env.STRIPE_KEY = 'sk';
+process.env.TWILIO_SID = 'sid';
+process.env.TWILIO_TOKEN = 'token';
+process.env.S3_BUCKET = 'bucket';
+
 const { app } = require('../../app');
 const { issueToken } = require('../../auth');
 const { __rides } = require('pg');

--- a/server/src/rides/__tests__/sms.test.js
+++ b/server/src/rides/__tests__/sms.test.js
@@ -5,9 +5,13 @@ jest.mock('twilio', () => jest.fn(() => ({
 describe('sendSMS', () => {
   beforeEach(() => {
     jest.resetModules();
-    process.env.TWILIO_ACCOUNT_SID = 'sid';
-    process.env.TWILIO_AUTH_TOKEN = 'token';
+    process.env.DATABASE_URL = 'postgres://test';
+    process.env.JWT_SECRET = 'secret';
+    process.env.STRIPE_KEY = 'sk';
+    process.env.TWILIO_SID = 'sid';
+    process.env.TWILIO_TOKEN = 'token';
     process.env.TWILIO_FROM_PHONE = '+1';
+    process.env.S3_BUCKET = 'bucket';
   });
 
   test('sends sms via twilio', async () => {

--- a/server/src/rides/rides.test.js
+++ b/server/src/rides/rides.test.js
@@ -1,6 +1,12 @@
 jest.mock('pg');
 
 const request = require('supertest');
+process.env.DATABASE_URL = 'postgres://test';
+process.env.JWT_SECRET = 'secret';
+process.env.STRIPE_KEY = 'sk';
+process.env.TWILIO_SID = 'sid';
+process.env.TWILIO_TOKEN = 'token';
+process.env.S3_BUCKET = 'bucket';
 const { app, pool } = require('../app');
 const { __rides } = require('pg');
 

--- a/server/src/rides/sms.js
+++ b/server/src/rides/sms.js
@@ -1,8 +1,9 @@
 const twilio = require('twilio');
+const { config } = require('../../../src/config/env');
 
-const accountSid = process.env.TWILIO_ACCOUNT_SID;
-const authToken = process.env.TWILIO_AUTH_TOKEN;
-const fromPhone = process.env.TWILIO_FROM_PHONE;
+const accountSid = config.TWILIO_SID;
+const authToken = config.TWILIO_TOKEN;
+const fromPhone = config.TWILIO_FROM_PHONE;
 
 let client;
 

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -1,0 +1,36 @@
+const { config: load } = require('dotenv');
+const { z } = require('zod');
+
+load();
+
+const env = {
+  DATABASE_URL: process.env.DATABASE_URL,
+  JWT_SECRET: process.env.JWT_SECRET,
+  STRIPE_KEY: process.env.STRIPE_KEY || process.env.STRIPE_SECRET_KEY,
+  TWILIO_SID: process.env.TWILIO_SID || process.env.TWILIO_ACCOUNT_SID,
+  TWILIO_TOKEN: process.env.TWILIO_TOKEN || process.env.TWILIO_AUTH_TOKEN,
+  S3_BUCKET: process.env.S3_BUCKET,
+  PORT: process.env.PORT,
+  STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET,
+  TWILIO_FROM_PHONE: process.env.TWILIO_FROM_PHONE,
+  NODE_ENV: process.env.NODE_ENV,
+};
+
+const schema = z.object({
+  DATABASE_URL: z.string().nonempty(),
+  JWT_SECRET: z.string().nonempty(),
+  STRIPE_KEY: z.string().nonempty(),
+  TWILIO_SID: z.string().nonempty(),
+  TWILIO_TOKEN: z.string().nonempty(),
+  S3_BUCKET: z.string().nonempty(),
+});
+
+const result = schema.safeParse(env);
+if (!result.success) {
+  const missing = result.error.errors.map(e => e.path[0]).join(', ');
+  throw new Error(`Missing required env vars: ${missing}`);
+}
+
+const config = Object.freeze({ ...env, ...result.data });
+
+module.exports = { config };


### PR DESCRIPTION
## Summary
- add `src/config/env.js` to load and validate environment vars
- refactor server utilities and tests to import the frozen config object
- update package dependencies for `zod`

## Testing
- `npm install --ignore-scripts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a66ac32c0832684460f51539d66f7