### PR TITLE
Add note about using npx --yes for Jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ For coverage reporting (fails under 80%), run:
 ```bash
 npm run test:ci
 ```
+If you prefer to invoke Jest directly, pass the `--yes` flag to `npx` to skip the
+installation prompt:
+```bash
+npx --yes jest --runInBand --no-colors
+```
 
 
 ## Docker image

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -31,6 +31,10 @@ This document provides an overview of the repository layout and tips for local d
    npm run lint
    npm test
    ```
+   To run Jest directly without npm prompting for confirmation, use:
+   ```bash
+   npx --yes jest --runInBand --no-colors
+   ```
 
 ### Seeding the database
 


### PR DESCRIPTION
## Summary
- clarify how to run Jest directly via npx without confirmation prompts
- add same note in development guide

## Testing
- `npx --yes jest --runInBand --no-colors server/src/auth/__tests__/auth.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684a6aca60788326980165d3af42ea8b