### PR TITLE
Add Zod validation middleware

### DIFF
--- a/server/src/middleware/validate.js
+++ b/server/src/middleware/validate.js
@@ -1,0 +1,58 @@
+const { z } = require('zod');
+
+function validate(schema) {
+  return (req, res, next) => {
+    const data = { body: req.body, params: req.params, query: req.query };
+    const result = schema.safeParse(data);
+    if (!result.success) {
+      return res.status(422).json({ error: result.error.errors[0].message });
+    }
+    req.validated = result.data;
+    next();
+  };
+}
+
+const bookRideSchema = z.object({
+  body: z.object({
+    pickup_address: z.string().min(1),
+    dropoff_address: z.string().min(1),
+    pickup_time: z
+      .string()
+      .refine((v) => !isNaN(Date.parse(v)), 'pickup_time must be ISO')
+      .refine(
+        (v) => new Date(v).getTime() - Date.now() >= 7 * 24 * 60 * 60 * 1000,
+        'pickup_time must be at least 7 days in the future'
+      ),
+    payment_type: z.enum(['insurance', 'card'])
+  })
+});
+
+const loginSchema = z.object({
+  body: z.object({
+    email: z.string().email(),
+    password: z.string().min(8)
+  })
+});
+
+const signupSchema = loginSchema; // same fields for this demo
+
+const ridesQuerySchema = z.object({
+  query: z.object({
+    status: z.string().optional(),
+    driver_id: z.string().optional(),
+    patient_id: z.string().optional()
+  })
+});
+
+const idSchema = z.object({
+  params: z.object({ id: z.string().uuid() })
+});
+
+module.exports = {
+  validate,
+  bookRideSchema,
+  loginSchema,
+  signupSchema,
+  ridesQuerySchema,
+  idSchema
+};

--- a/server/src/rides/rides.test.js
+++ b/server/src/rides/rides.test.js
@@ -28,7 +28,7 @@ describe('/rides booking endpoint', () => {
     expect(res.status).toBe(201);
   });
 
-  test('booking <7 days ahead returns 400', async () => {
+  test('booking <7 days ahead returns 422', async () => {
     const soon = new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString();
     const res = await request(app)
       .post('/rides')
@@ -38,7 +38,7 @@ describe('/rides booking endpoint', () => {
         dropoff_address: 'B',
         payment_type: 'card'
       });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
   });
 
   test('DB row count increases on success', async () => {
@@ -61,12 +61,12 @@ describe('/rides booking endpoint', () => {
     expect(after).toBe(before + 1);
   });
 
-  test('missing fields return 400', async () => {
+  test('missing fields return 422', async () => {
     const future = new Date(Date.now() + 8 * 24 * 60 * 60 * 1000).toISOString();
     const res = await request(app)
       .post('/rides')
       .send({ pickup_time: future, dropoff_address: 'B', payment_type: 'card' });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
   });
 
   test('database errors return 500', async () => {


### PR DESCRIPTION
## Summary
- add `validate` middleware using Zod
- secure ride booking, login and signup routes
- refactor rides tests to expect 422 validation errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a773c27bc8326b639a1696085da97