### PR TITLE
Use Feather icons in driver dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "pino-http": "^10.5.0",
         "pino-pretty": "^13.0.0",
         "prom-client": "^15.1.3",
+        "react-feather": "^2.0.10",
         "socket.io": "^4.7.2",
         "stripe": "^12.0.0",
         "twilio": "^4.16.0",
@@ -4640,7 +4641,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4946,6 +4946,18 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -5865,6 +5877,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -5979,6 +6008,28 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-feather": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/react-feather/-/react-feather-2.0.10.tgz",
+      "integrity": "sha512-BLhukwJ+Z92Nmdcs+EMw6dy1Z/VLiJTzEQACDUEnWMClhYnFykJCGWQx+NmwP/qQHGX/5CzQ+TGi8ofg2+HzVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.6"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "pino-http": "^10.5.0",
     "pino-pretty": "^13.0.0",
     "prom-client": "^15.1.3",
+    "react-feather": "^2.0.10",
     "socket.io": "^4.7.2",
     "stripe": "^12.0.0",
     "twilio": "^4.16.0",

--- a/public/driver-dashboard.html
+++ b/public/driver-dashboard.html
@@ -6,6 +6,7 @@
   <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
   <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-feather/dist/react-feather.min.js"></script>
   <style>
     body {
       font-family: Arial, sans-serif;
@@ -33,6 +34,17 @@
 
   <script type="text/babel">
     const { useState, useEffect } = React;
+    const { Calendar, Map, DollarSign } = ReactFeather;
+
+    function BottomNav() {
+      return (
+        <nav className="fixed bottom-0 inset-x-0 bg-white border-t flex justify-around p-2">
+          <button aria-label="book"><Calendar /></button>
+          <button aria-label="rides"><Map /></button>
+          <button aria-label="earnings"><DollarSign /></button>
+        </nav>
+      );
+    }
 
     function DriverDashboard() {
       const [rides, setRides] = useState([]);
@@ -63,7 +75,13 @@
       );
     }
 
-    ReactDOM.render(<DriverDashboard />, document.getElementById('root'));
+    ReactDOM.render(
+      <>
+        <DriverDashboard />
+        <BottomNav />
+      </>,
+      document.getElementById('root')
+    );
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `react-feather` dependency
- integrate Feather icons in driver dashboard
- render a bottom navigation with accessible icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a8a785a648326b091895ed3a7234f