### PR TITLE
Add coverage gate script

### DIFF
--- a/.github/scripts/coverage-gate.sh
+++ b/.github/scripts/coverage-gate.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
-set -euo pipefail
-pct=$(grep -o '"statements"[^}]*' coverage/coverage-summary.json | head -n 1 | grep -o '"pct":[0-9.]*' | grep -o '[0-9.]*')
-echo "Statements coverage: $pct"
-if [ "$(printf '%.*f' 0 "$pct")" -lt 80 ]; then
-  echo "Coverage below 80%"
+set -e
+THRESHOLD=80
+LINES=$(node - <<'JS'
+const fs=require('fs');
+const data=JSON.parse(fs.readFileSync('coverage/coverage-summary.json'));
+console.log(data.total.lines.pct);
+JS
+)
+echo "Line coverage = $LINES%"
+if (( $(echo "$LINES < $THRESHOLD" | bc -l) )); then
+  echo "❌ Coverage below ${THRESHOLD}%"
   exit 1
 fi
+echo "✅ Coverage sufficient"


### PR DESCRIPTION
## Summary
- check coverage using a bash script

## Testing
- `npm test`
- `npm run test:ci` *(fails: make-coverage-badge can't reach network)*
- `bash .github/scripts/coverage-gate.sh` *(fails: bc not found, but prints coverage)*

------
https://chatgpt.com/codex/tasks/task_e_684a9569a70c83268581476cd6832f6d