### PR TITLE
Add basic controller and auth tests

### DIFF
--- a/tests/auth.middleware.spec.js
+++ b/tests/auth.middleware.spec.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const request = require('supertest');
+const { authenticate, issueToken } = require('../src/modules/auth/service');
+
+describe('auth middleware', () => {
+  let app;
+  beforeEach(() => {
+    app = express();
+    app.get('/private', authenticate, (req, res) => res.json({ ok: true }));
+  });
+
+  test('missing token -> 401', async () => {
+    const res = await request(app).get('/private');
+    expect(res.status).toBe(401);
+  });
+
+  test('invalid token -> 401', async () => {
+    const res = await request(app)
+      .get('/private')
+      .set('Authorization', 'Bearer bad');
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/ride.controller.spec.js
+++ b/tests/ride.controller.spec.js
@@ -1,0 +1,35 @@
+const request = require('supertest');
+jest.mock('@prisma/client');
+
+const { app } = require('../src/app');
+
+const { __rides } = require('@prisma/client');
+describe('POST /rides controller', () => {
+  beforeEach(async () => {
+    __rides.length = 0;
+  });
+
+  test('happy path returns 201', async () => {
+    const future = new Date(Date.now() + 8 * 24 * 60 * 60 * 1000).toISOString();
+    const res = await request(app).post('/rides').send({
+      pickup_time: future,
+      pickup_address: 'A',
+      dropoff_address: 'B',
+      payment_type: 'card',
+    });
+    expect(res.status).toBe(201);
+    expect(__rides).toHaveLength(1);
+  });
+
+  test('pickup_time < 7 days returns 422', async () => {
+    const soon = new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString();
+    const res = await request(app).post('/rides').send({
+      pickup_time: soon,
+      pickup_address: 'A',
+      dropoff_address: 'B',
+      payment_type: 'card',
+    });
+    expect(res.status).toBe(422);
+    expect(__rides).toHaveLength(0);
+  });
+});

--- a/tests/stripe.webhook.spec.js
+++ b/tests/stripe.webhook.spec.js
@@ -1,0 +1,60 @@
+const express = require('express');
+const request = require('supertest');
+jest.mock('@prisma/client');
+const { __rides } = require('@prisma/client');
+process.env.DATABASE_URL = 'postgres://test';
+process.env.JWT_SECRET = 'secret';
+process.env.STRIPE_KEY = 'sk';
+process.env.TWILIO_SID = 'sid';
+process.env.TWILIO_TOKEN = 'token';
+process.env.S3_BUCKET = 'bucket';
+process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test';
+const createWebhookRouter = require('../src/modules/payments/routes');
+const stripe = require('stripe')('sk_test');
+
+describe('stripe webhook route', () => {
+  beforeEach(() => {
+    __rides.length = 0;
+    __rides.push({ id: 1, stripe_payment_id: 'pi_123', status: 'pending' });
+  });
+
+  test('constructEvent throws -> 400', async () => {
+    jest.spyOn(stripe.webhooks, 'constructEvent').mockImplementation(() => {
+      throw new Error('bad');
+    });
+    const app = express();
+    app.use(createWebhookRouter());
+    const res = await request(app)
+      .post('/webhook/stripe')
+      .set('Stripe-Signature', 'sig')
+      .set('Content-Type', 'application/json')
+      .send('{}');
+    expect(res.status).toBe(400);
+  });
+
+  test('success updates ride status', async () => {
+    const payload = JSON.stringify({
+      type: 'payment_intent.succeeded',
+      data: { object: { id: 'pi_123' } },
+    });
+    const header = stripe.webhooks.generateTestHeaderString({
+      payload,
+      secret: 'whsec_test',
+    });
+    const app = express();
+    const emit = jest.fn();
+    const io = { to: jest.fn(() => ({ emit })) };
+    app.use(createWebhookRouter(io));
+    const res = await request(app)
+      .post('/webhook/stripe')
+      .set('Stripe-Signature', header)
+      .set('Content-Type', 'application/json')
+      .send(payload);
+    expect(res.status).toBe(200);
+    expect(__rides[0].status).toBe('confirmed');
+    expect(emit).toHaveBeenCalledWith(
+      'payment_confirmed',
+      expect.objectContaining({ id: 1 }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add ride controller happy & edge tests
- test auth middleware scenarios
- verify stripe webhook handler

## Testing
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_684a993a7400832681fd87871cd6423b