### PR TITLE
Add helper script for local Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,24 @@ Run the entire stack with Docker Compose:
 docker compose up
 ```
 
+## Local setup
+
+For environments where Docker Compose isn't available, you can run the API with a
+local Postgres instance:
+
+1. Install Postgres:
+   ```bash
+   brew install postgres
+   ```
+2. Start Postgres locally:
+   ```bash
+   ./scripts/local-postgres.sh
+   ```
+3. Launch the server pointing `DATABASE_URL` at the new database:
+   ```bash
+   DATABASE_URL=postgresql://localhost:5433/chario_local npm run dev
+   ```
+
 ## API reference
 
 | Method | Path | Auth | Description |

--- a/scripts/local-postgres.sh
+++ b/scripts/local-postgres.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Start single-user Postgres on a random port
+pg_ctl -D .pgdata -o "-F -p 5433" -l logfile start
+createdb -p 5433 chario_local || true


### PR DESCRIPTION
## Summary
- add `scripts/local-postgres.sh`
- document alternative local setup without Docker Compose

## Testing
- `npx --yes jest --runInBand --no-colors`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a9a603804832698f204617b057329