### PR TITLE
Fix test env handling and migrations

### DIFF
--- a/migrations/20250612035736_init.js
+++ b/migrations/20250612035736_init.js
@@ -1,21 +1,21 @@
-exports.up = async function(knex) {
+exports.up = async function (knex) {
   await knex.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"');
 
-  await knex.schema.createTable('patients', table => {
+  await knex.schema.createTable('patients', (table) => {
     table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
     table.text('name').notNullable();
     table.text('phone').notNullable();
     table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
   });
 
-  await knex.schema.createTable('drivers', table => {
+  await knex.schema.createTable('drivers', (table) => {
     table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
     table.text('name').notNullable();
     table.text('phone').notNullable();
     table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
   });
 
-  await knex.schema.createTable('payments', table => {
+  await knex.schema.createTable('payments', (table) => {
     table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
     table.decimal('amount', 10, 2).notNullable();
     table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
@@ -29,48 +29,65 @@ exports.up = async function(knex) {
     END $$;
   `);
 
-  await knex.schema.createTable('rides', table => {
+  await knex.schema.createTable('rides', (table) => {
     table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
-    table.uuid('patient_id').references('id').inTable('patients').onDelete('SET NULL');
-    table.uuid('driver_id').references('id').inTable('drivers').onDelete('SET NULL');
+    table
+      .uuid('patient_id')
+      .references('id')
+      .inTable('patients')
+      .onDelete('SET NULL');
+    table
+      .uuid('driver_id')
+      .references('id')
+      .inTable('drivers')
+      .onDelete('SET NULL');
     table.timestamp('pickup_time').notNullable();
     table.text('pickup_address').notNullable();
     table.text('dropoff_address').notNullable();
     table.text('payment_type').notNullable();
-    table.enu('status', ['pending', 'confirmed', 'completed'], { useNative: true, enumName: 'ride_status' }).notNullable().defaultTo('pending');
+    table
+      .enu('status', ['pending', 'confirmed', 'completed'], {
+        useNative: true,
+        enumName: 'ride_status',
+        existingType: true,
+      })
+      .notNullable()
+      .defaultTo('pending');
     table.uuid('insurance_id');
     table.text('stripe_payment_id');
     table.timestamp('completed_at');
     table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
   });
 
-  await knex.schema.createTable('insurance_docs', table => {
+  await knex.schema.createTable('insurance_docs', (table) => {
     table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
     table.uuid('ride_id').references('id').inTable('rides').onDelete('CASCADE');
     table.text('s3_key').notNullable();
     table.timestamp('uploaded_at').notNullable().defaultTo(knex.fn.now());
   });
 
-  await knex.schema.createTable('audit_logs', table => {
+  await knex.schema.createTable('audit_logs', (table) => {
     table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
     table.uuid('user_id');
     table.text('action').notNullable();
     table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
   });
 
-  await knex.schema.raw('CREATE INDEX idx_rides_pickup_time ON rides(pickup_time)');
+  await knex.schema.raw(
+    'CREATE INDEX idx_rides_pickup_time ON rides(pickup_time)',
+  );
   await knex.schema.raw('CREATE INDEX idx_rides_status ON rides(status)');
   await knex.schema.raw('CREATE INDEX idx_audit_user ON audit_logs(user_id)');
 };
 
-exports.down = async function(knex) {
+exports.down = async function (knex) {
   await knex.schema.raw('DROP INDEX IF EXISTS idx_audit_user');
   await knex.schema.raw('DROP INDEX IF EXISTS idx_rides_status');
   await knex.schema.raw('DROP INDEX IF EXISTS idx_rides_pickup_time');
   await knex.schema.dropTableIfExists('audit_logs');
   await knex.schema.dropTableIfExists('insurance_docs');
   await knex.schema.dropTableIfExists('rides');
-  await knex.schema.raw("DROP TYPE IF EXISTS ride_status");
+  await knex.schema.raw('DROP TYPE IF EXISTS ride_status');
   await knex.schema.dropTableIfExists('payments');
   await knex.schema.dropTableIfExists('drivers');
   await knex.schema.dropTableIfExists('patients');

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -1,8 +1,17 @@
 const { config: dotenvSafe } = require('dotenv-safe');
 const { z } = require('zod');
+const path = require('path');
 
-// Load environment variables. Tests inject values so allow empty ones.
-dotenvSafe({ allowEmptyValues: true });
+// Load environment variables. During tests, rely solely on process.env
+if (process.env.NODE_ENV === 'test') {
+  dotenvSafe({
+    allowEmptyValues: true,
+    path: path.resolve(__dirname, '../../.env.test'), // skip loading .env
+    example: path.resolve(__dirname, '../../.env.example'),
+  });
+} else {
+  dotenvSafe({ allowEmptyValues: true });
+}
 
 const env = {
   DATABASE_URL: process.env.DATABASE_URL,


### PR DESCRIPTION
## Summary
- ensure env loader ignores `.env` during tests
- create `.env.test` placeholder
- adjust enum creation to avoid conflicts

## Testing
- `npm run migrate --silent`
- `npm run seed`
- `npm run test`
- `npm run test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_684a9cbc3924832695ff27881bb33848