### PR TITLE
Add audit logging middleware

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,8 +62,10 @@ model InsuranceDoc {
 }
 
 model AuditLog {
-  id         String   @id @default(uuid()) @db.Uuid
-  user_id    String?  @db.Uuid
-  action     String
-  created_at DateTime @default(now()) @db.Timestamptz
+  id        String   @id @default(uuid()) @db.Uuid
+  userId    String?  @db.Uuid
+  method    String
+  path      String
+  bodyHash  String
+  createdAt DateTime @default(now()) @db.Timestamptz
 }

--- a/src/app.js
+++ b/src/app.js
@@ -17,7 +17,7 @@ const cron = require('node-cron');
 const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
 const { logAudit } = require('./utils/audit');
-const audit = require('./utils/middleware/audit');
+const audit = require('./middleware/audit');
 const {
   validate,
   bookRideSchema,

--- a/src/middleware/audit.js
+++ b/src/middleware/audit.js
@@ -1,0 +1,21 @@
+const crypto = require('crypto');
+const { prisma } = require('../utils/db');
+
+module.exports = (req, res, next) => {
+  if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) {
+    prisma.auditLog
+      .create({
+        data: {
+          userId: req.user?.id || null,
+          method: req.method,
+          path: req.originalUrl,
+          bodyHash: crypto
+            .createHash('sha256')
+            .update(JSON.stringify(req.body ?? {}))
+            .digest('hex'),
+        },
+      })
+      .catch(console.error);
+  }
+  next();
+};

--- a/src/utils/audit.js
+++ b/src/utils/audit.js
@@ -1,5 +1,6 @@
 const { prisma } = require('./db');
 const { getLogger } = require('./logger');
+const crypto = require('crypto');
 
 const log = getLogger(__filename);
 
@@ -10,7 +11,12 @@ const log = getLogger(__filename);
  */
 async function logAudit(userId, action) {
   try {
-    await prisma.auditLog.create({ data: { user_id: userId, action } });
+    const [method, ...pathParts] = action.split(' ');
+    const path = pathParts.join(' ');
+    const bodyHash = crypto.createHash('sha256').update('').digest('hex');
+    await prisma.auditLog.create({
+      data: { userId, method, path, bodyHash },
+    });
   } catch (err) {
     log.error({ err }, 'Failed to record audit log');
   }


### PR DESCRIPTION
## Summary
- add audit log middleware to capture writes
- wire middleware into app
- update Prisma AuditLog model
- adjust logAudit helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aa64058788326bbeb3d713119060b