### PR TITLE
Add nightly payout reconciliation job

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "prepare": "husky install",
     "test:ci": "jest --coverage --coverageReporters=text --coverageReporters=lcov --coverageReporters=json-summary && npx --yes make-coverage-badge --report-path coverage/coverage-summary.json --output-path coverage.svg",
     "migrate": "knex migrate:latest",
-    "seed": "node seed.js"
+    "seed": "node seed.js",
+    "cron:reconcile": "node scripts/reconcile.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/reconcile.js
+++ b/scripts/reconcile.js
@@ -1,0 +1,42 @@
+const cron = require('node-cron');
+const { config } = require('../src/config/env');
+const stripe = require('stripe')(config.STRIPE_KEY);
+const { prisma } = require('../src/utils/db');
+const { getLogger } = require('../src/utils/logger');
+
+const log = getLogger(__filename);
+
+async function reconcile() {
+  try {
+    const rides = await prisma.ride.findMany({
+      where: { status: 'completed', payoutId: null },
+      include: {
+        driver: { select: { stripeAccountId: true } },
+      },
+    });
+    for (const ride of rides) {
+      if (!ride.driver || !ride.driver.stripeAccountId) {
+        log.warn({ rideId: ride.id }, 'No driver stripe account');
+        continue;
+      }
+      const amount = Math.round(Number(ride.amount || 0) * 100);
+      const transfer = await stripe.transfers.create({
+        amount,
+        currency: 'usd',
+        destination: ride.driver.stripeAccountId,
+      });
+      await prisma.ride.update({
+        where: { id: ride.id },
+        data: { payoutId: transfer.id },
+      });
+      log.info(
+        { rideId: ride.id, transferId: transfer.id },
+        'Payout reconciled',
+      );
+    }
+  } catch (err) {
+    log.error({ err }, 'Reconcile failed');
+  }
+}
+
+cron.schedule('0 3 * * *', reconcile);


### PR DESCRIPTION
## Summary
- add a cron script to reconcile driver payouts via Stripe
- expose the script through `npm run cron:reconcile`

## Testing
- `npm run lint`
- `npx --yes jest --runInBand --no-colors --json --outputFile=/tmp/test.json`
- `cat /tmp/test.json | jq '.success,.numPassedTests'`


------
https://chatgpt.com/codex/tasks/task_e_684aa8bcd9ec832694cc46e51abcab4f