### PR TITLE
Implement static asset caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@prisma/client": "^6.9.0",
         "aws-sdk": "^2.1692.0",
         "basic-auth": "^2.0.1",
+        "connect-static": "^1.6.0",
         "dotenv": "^16.4.1",
         "express": "^5.1.0",
         "express-rate-limit": "^7.5.0",
@@ -2520,6 +2521,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/connect-static": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/connect-static/-/connect-static-1.6.0.tgz",
+      "integrity": "sha512-kcKZpwyxVSVxW0hPvSrHXEP8Q7VAUzZ/+kC/w64ZghQoPCH+8vQBPFoe8BN48gEGpaopJHNreNKVqByuxMhwDg==",
+      "license": "MIT",
+      "dependencies": {
+        "findit2": "~2.2.3",
+        "mime": "~2.4.4",
+        "pend": "~1.2.0",
+        "streamsink": "~1.2.0"
+      }
+    },
+    "node_modules/connect-static/node_modules/mime": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
+      "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
@@ -3925,6 +3950,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/findit2": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/findit2/-/findit2-2.2.3.tgz",
+      "integrity": "sha512-lg/Moejf4qXovVutL0Lz4IsaPoNYMuxt4PA0nGqFxnJ1CTTGGlEO2wKgoDpwknhvZ8k4Q2F+eesgkLbG2Mxfog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.22"
       }
     },
     "node_modules/flat-cache": {
@@ -7308,6 +7342,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/pg": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.0.tgz",
@@ -8766,6 +8806,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/streamsink": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/streamsink/-/streamsink-1.2.0.tgz",
+      "integrity": "sha512-MJ440L2+j2vmc1v8Z/BkMx3X+HsJ++V7mgDROboQKxqCLZdNbu+AeSwQbayXw3LPHVAMxw+h7ZJUnyFYl/zp2g==",
+      "license": "MIT"
     },
     "node_modules/string-argv": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@prisma/client": "^6.9.0",
     "aws-sdk": "^2.1692.0",
     "basic-auth": "^2.0.1",
+    "connect-static": "^1.6.0",
     "dotenv": "^16.4.1",
     "express": "^5.1.0",
     "express-rate-limit": "^7.5.0",

--- a/src/app.js
+++ b/src/app.js
@@ -54,7 +54,7 @@ app.use(observeRequest);
 
 app.use(helmet());
 app.use(rateLimit({ windowMs: 15 * 60 * 1000, max: 300 }));
-app.use(express.static('public'));
+app.use('/static', express.static('public', { maxAge: '30d', etag: true }));
 
 // Simple health endpoint for containers
 app.get('/healthz', (req, res) => res.send('ok'));

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -29,6 +29,7 @@ const env = {
   NODE_ENV: process.env.NODE_ENV,
   METRICS_USER: process.env.METRICS_USER,
   METRICS_PASS: process.env.METRICS_PASS,
+  COMMIT_SHA: process.env.COMMIT_SHA,
 };
 
 const schema = z.object({


### PR DESCRIPTION
## Summary
- install connect-static
- serve static files under `/static` with caching
- expose `COMMIT_SHA` via config

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684aacd095b08326aea58367d2d5bb65