### PR TITLE
Add a11y lint config and test

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,11 +1,23 @@
+const reactPlugin = require('eslint-plugin-react');
+const jsxA11y = require('eslint-plugin-jsx-a11y');
+
 module.exports = [
   {
-    files: ['**/*.js'],
+    files: ['**/*.{js,jsx}'],
     ignores: ['node_modules/**', 'coverage/**'],
     languageOptions: {
-      ecmaVersion: 12,
-      sourceType: 'script',
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
     },
-    rules: {},
+    plugins: {
+      react: reactPlugin,
+      'jsx-a11y': jsxA11y,
+    },
+    rules: {
+      ...jsxA11y.configs.recommended.rules,
+    },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "jest",
     "test:coverage": "cross-env NODE_ENV=test jest --coverage --runInBand --coverageReporters=lcov --coverageReporters=json-summary",
     "start": "node index.js",
-    "lint": "eslint . --ignore-pattern \"coverage/**\"",
+    "lint": "ESLINT_USE_FLAT_CONFIG=true eslint . --ignore-pattern \"coverage/**\"",
     "prepare": "husky install",
     "test:ci": "jest --coverage --coverageReporters=text --coverageReporters=lcov --coverageReporters=json-summary && npx --yes make-coverage-badge --report-path coverage/coverage-summary.json --output-path coverage.svg",
     "migrate": "knex migrate:latest",

--- a/tests/accessibility.spec.js
+++ b/tests/accessibility.spec.js
@@ -11,6 +11,5 @@ expect.extend(toHaveNoViolations);
 
 test('BookingForm is accessible', async () => {
   const { container } = render(React.createElement(BookingForm));
-  const results = await axe(container);
-  expect(results).toHaveNoViolations();
+  await expect(axe(container)).resolves.toHaveNoViolations();
 });


### PR DESCRIPTION
## Summary
- enable jsx-a11y plugin via flat ESLint config
- run ESLint with flat config
- check `<BookingForm />` accessibility in tests

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684ab1455c8c8326a39046797e5928fc