### PR TITLE
Add CodeQL and secret scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
           --health-retries=5
     steps:
       - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -33,3 +36,8 @@ jobs:
         env:
           DATABASE_URL: 'postgresql://chario:chario@localhost:5432/chario_test'
       - run: bash .github/scripts/coverage-gate.sh
+      - uses: github/codeql-action/analyze@v3
+      - uses: trufflesecurity/trufflehog@v3
+        with:
+          path: '.'
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -61,3 +61,9 @@ local Postgres instance:
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+## Security
+
+GitHub Advanced Security is enabled. The CI workflow runs CodeQL analysis and
+TruffleHog secret scanning on every push to prevent vulnerable dependencies and
+leaked credentials.


### PR DESCRIPTION
## Summary
- use codeql and trufflehog in CI
- document security scanning in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ab1e1a62c8326b350381888d40b08