### PR TITLE
Fix invalid TruffleHog action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           DATABASE_URL: 'postgresql://chario:chario@localhost:5432/chario_test'
       - run: bash .github/scripts/coverage-gate.sh
       - uses: github/codeql-action/analyze@v3
-      - uses: trufflesecurity/trufflehog@v3
+      - uses: trufflesecurity/trufflehog@v3.89.1
         with:
           path: '.'
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- pin TruffleHog GitHub Action version to v3.89.1 in workflow

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b06d73aa08326b3dc772dc366f724