### PR TITLE
Fix CI database setup and mock Stripe webhooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: 'postgresql://chario:chario@localhost:5432/chario_test'
     services:
       postgres:
         image: postgres:15-alpine
@@ -29,13 +31,11 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
+      - name: Create chario database
+        run: psql postgresql://chario:chario@localhost:5432/postgres -c "CREATE DATABASE chario;"
       - run: npx markdown-lint docs/**/*.md
       - run: npx prisma migrate deploy
-        env:
-          DATABASE_URL: 'postgresql://chario:chario@localhost:5432/chario_test'
       - run: npm run test:coverage
-        env:
-          DATABASE_URL: 'postgresql://chario:chario@localhost:5432/chario_test'
       - run: bash .github/scripts/coverage-gate.sh
       - uses: github/codeql-action/analyze@v3
       - uses: trufflesecurity/trufflehog@v3.89.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "jest-environment-jsdom": "^30.0.0",
         "lint-staged": "^15.2.0",
         "make-coverage-badge": "^1.2.0",
+        "nock": "^13.5.0",
         "prettier": "^3.2.5",
         "prisma": "^6.9.0",
         "react": "^19.1.0",
@@ -8641,6 +8642,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -9729,6 +9737,21 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/nock": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
+      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
@@ -10632,6 +10655,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "react-dom": "^19.1.0",
     "react-toastify": "^11.0.5",
     "supertest": "^6.3.3",
-    "tailwindcss": "^4.1.10"
+    "tailwindcss": "^4.1.10",
+    "nock": "^13.5.0"
   },
   "jest": {
     "setupFiles": [

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -1,3 +1,6 @@
+const nock = require('nock');
+nock('https://api.stripe.com').post(/.*/).reply(200, { success: true });
+
 process.env = {
   ...process.env,
   DATABASE_URL: 'postgresql://chario:chario@localhost:5432/chario_test',


### PR DESCRIPTION
## Summary
- create missing `chario` database in CI workflow
- pass database URL at the job level
- mock Stripe webhook calls in tests
- include `nock` test dependency

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b094f76b08326bd168766ada1d54f