### PR TITLE
Add Grafana dashboard

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -62,3 +62,7 @@ available per module. Prometheus metrics are served from `/metrics` and include
 request latency and failed ride counters. Access to the metrics endpoint is
 protected with basic authentication. The container exposes port `9100` for
 Prometheus scraping.
+
+The repository includes a Grafana dashboard definition at
+`ops/grafana/chario_dashboard.json`. Operations teams should import this file
+using Terraform or the Grafana HTTP API so metrics show up automatically.

--- a/ops/grafana/chario_dashboard.json
+++ b/ops/grafana/chario_dashboard.json
@@ -1,0 +1,61 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "refId": "A"
+        }
+      ],
+      "title": "p95 request latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "id": 2,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "expr": "sum(rate(http_request_duration_seconds_count{status_code=~\"5..\"}[5m])) / sum(rate(http_request_duration_seconds_count[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "5xx error rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": {}, "overrides": [] },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "id": 3,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        {
+          "expr": "sum(rate(failed_rides_total[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "failed_rides counter",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": ["chario"],
+  "time": { "from": "now-6h", "to": "now" },
+  "title": "CHARIO Overview",
+  "version": 1
+}


### PR DESCRIPTION
## Summary
- add initial Grafana dashboard under `ops/grafana`
- document how to import the dashboard

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b107942b083269e197dd78a79d1e1