### PR TITLE
Implement secure auth module with JWT and OTP

### DIFF
--- a/__mocks__/@prisma/client.js
+++ b/__mocks__/@prisma/client.js
@@ -1,6 +1,8 @@
 const rides = [];
 const insuranceDocs = [];
 const auditLogs = [];
+const users = [];
+const sessions = [];
 
 class PrismaClient {
   constructor() {
@@ -77,6 +79,37 @@ class PrismaClient {
         auditLogs.push({ id: String(auditLogs.length + 1), ...data });
       },
     };
+
+    this.user = {
+      create: async ({ data }) => {
+        const user = { id: String(users.length + 1), ...data };
+        users.push(user);
+        return user;
+      },
+      findUnique: async ({ where }) => {
+        if (where.id) return users.find((u) => u.id === where.id) || null;
+        if (where.email)
+          return users.find((u) => u.email === where.email) || null;
+        return null;
+      },
+    };
+
+    this.session = {
+      create: async ({ data }) => {
+        const session = { id: String(sessions.length + 1), ...data };
+        sessions.push(session);
+        return session;
+      },
+      findUnique: async ({ where }) => {
+        return sessions.find((s) => s.id === where.id) || null;
+      },
+      update: async ({ where, data }) => {
+        const session = sessions.find((s) => s.id === where.id);
+        if (!session) throw new Error('not found');
+        Object.assign(session, data);
+        return session;
+      },
+    };
     this.$queryRaw = async () => [{ '?column?': 1 }];
   }
 }
@@ -85,4 +118,6 @@ module.exports = {
   PrismaClient,
   __rides: rides,
   __insuranceDocs: insuranceDocs,
+  __users: users,
+  __sessions: sessions,
 };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "pino-pretty": "^13.0.0",
     "prom-client": "^15.1.3",
     "react-feather": "^2.0.10",
+    "bcryptjs": "^2.4.3",
     "socket.io": "^4.7.2",
     "stripe": "^12.0.0",
     "twilio": "^4.16.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,3 +69,22 @@ model AuditLog {
   bodyHash  String
   createdAt DateTime @default(now()) @db.Timestamptz
 }
+
+model User {
+  id           String    @id @default(uuid()) @db.Uuid
+  email        String    @unique
+  phone        String
+  passwordHash String
+  role         String
+  sessions     Session[]
+  createdAt    DateTime  @default(now()) @db.Timestamptz
+}
+
+model Session {
+  id        String   @id @default(uuid()) @db.Uuid
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String   @db.Uuid
+  tokenHash String
+  expiresAt DateTime @db.Timestamptz
+  revokedAt DateTime? @db.Timestamptz
+}

--- a/src/app.js
+++ b/src/app.js
@@ -14,6 +14,7 @@ const { payoutDriver } = require('./modules/payments/payouts');
 const createWebhookRouter = require('./modules/payments/routes');
 const createInsuranceRouter = require('./modules/insurance/routes');
 const { authenticate, issueToken } = require('./modules/auth/service');
+const createAuthRouter = require('./modules/auth/routes');
 const { sendSMS } = require('./modules/rides/service');
 const cron = require('node-cron');
 const helmet = require('helmet');
@@ -97,6 +98,7 @@ app.use(createWebhookRouter(io));
 app.use(express.json());
 app.use(audit);
 app.use(createInsuranceRouter());
+app.use('/auth', createAuthRouter());
 
 const users = new Map();
 

--- a/src/modules/auth/__tests__/auth.test.js
+++ b/src/modules/auth/__tests__/auth.test.js
@@ -1,28 +1,82 @@
+jest.mock('twilio', () =>
+  jest.fn(() => ({ messages: { create: jest.fn().mockResolvedValue(true) } })),
+);
+
 process.env.DATABASE_URL = 'postgres://test';
 process.env.JWT_SECRET = 'secret';
 process.env.STRIPE_KEY = 'sk';
 process.env.TWILIO_SID = 'sid';
 process.env.TWILIO_TOKEN = 'token';
+process.env.TWILIO_FROM_PHONE = '+1';
 process.env.S3_BUCKET = 'bucket';
-const { authenticate, issueToken } = require('../service');
 
-describe('auth module', () => {
-  test('issueToken and authenticate success', () => {
-    const token = issueToken({ id: 'user1', role: 'driver' });
-    const req = { header: () => `Bearer ${token}` };
-    const res = { status: jest.fn(() => res), json: jest.fn() };
-    const next = jest.fn();
-    authenticate(req, res, next);
-    expect(next).toHaveBeenCalled();
-    expect(req.user).toEqual({ id: 'user1', role: 'driver' });
+const request = require('supertest');
+const express = require('express');
+const createAuthRouter = require('../routes');
+const { __users, __sessions } = require('@prisma/client');
+const { _otpStore } = require('../service');
+
+describe('auth flow', () => {
+  let app;
+  beforeEach(() => {
+    jest.resetModules();
+    __users.length = 0;
+    __sessions.length = 0;
+    _otpStore.clear();
+    jest.spyOn(global.Math, 'random').mockReturnValue(0.5);
+    app = express();
+    app.use(express.json());
+    app.use('/auth', createAuthRouter());
   });
 
-  test('missing header returns 401', () => {
-    const req = { header: () => null };
-    const res = { status: jest.fn(() => res), json: jest.fn() };
-    const next = jest.fn();
-    authenticate(req, res, next);
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(next).not.toHaveBeenCalled();
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('register and login with password', async () => {
+    const res = await request(app)
+      .post('/auth/register')
+      .send({
+        email: 'a@b.com',
+        phone: '1',
+        password: 'pass',
+        role: 'patient',
+      });
+    expect(res.status).toBe(201);
+    expect(__users).toHaveLength(1);
+    const login = await request(app)
+      .post('/auth/login')
+      .send({ email: 'a@b.com', password: 'pass' });
+    expect(login.status).toBe(200);
+    expect(login.body).toHaveProperty('accessToken');
+    expect(login.body).toHaveProperty('refreshToken');
+  });
+
+  test('otp fallback and refresh rotation', async () => {
+    await request(app)
+      .post('/auth/register')
+      .send({
+        email: 'b@b.com',
+        phone: '2',
+        password: 'pass',
+        role: 'patient',
+      });
+    const fail = await request(app)
+      .post('/auth/login')
+      .send({ email: 'b@b.com', password: 'bad' });
+    expect(fail.status).toBe(401);
+    const code = '550000';
+    const login = await request(app)
+      .post('/auth/login')
+      .send({ email: 'b@b.com', otp: code });
+    const oldRefresh = login.body.refreshToken;
+    const refreshed = await request(app)
+      .post('/auth/token')
+      .send({ refreshToken: oldRefresh });
+    expect(refreshed.status).toBe(200);
+    const replay = await request(app)
+      .post('/auth/token')
+      .send({ refreshToken: oldRefresh });
+    expect(replay.status).toBe(401);
   });
 });

--- a/src/modules/auth/controller.js
+++ b/src/modules/auth/controller.js
@@ -1,1 +1,1 @@
-// empty module
+// placeholder controller for future expansion

--- a/src/modules/auth/routes.js
+++ b/src/modules/auth/routes.js
@@ -1,1 +1,48 @@
-// empty module
+const express = require('express');
+const { registerUser, loginUser, refreshTokens, logout } = require('./service');
+
+function createAuthRouter() {
+  const router = express.Router();
+
+  router.post('/register', async (req, res) => {
+    try {
+      const tokens = await registerUser(req.body);
+      res.status(201).json(tokens);
+    } catch (err) {
+      if (err.message === 'email exists') {
+        return res.status(409).json({ error: 'email already registered' });
+      }
+      return res.status(400).json({ error: 'invalid' });
+    }
+  });
+
+  router.post('/login', async (req, res) => {
+    try {
+      const tokens = await loginUser(req.body);
+      res.json(tokens);
+    } catch (err) {
+      if (err.message === 'otp') {
+        return res.status(401).json({ error: 'otp sent' });
+      }
+      return res.status(401).json({ error: 'invalid credentials' });
+    }
+  });
+
+  router.post('/token', async (req, res) => {
+    try {
+      const tokens = await refreshTokens(req.body.refreshToken);
+      res.json(tokens);
+    } catch (err) {
+      res.status(401).json({ error: 'invalid token' });
+    }
+  });
+
+  router.post('/logout', async (req, res) => {
+    await logout(req.body.refreshToken);
+    res.status(204).end();
+  });
+
+  return router;
+}
+
+module.exports = createAuthRouter;

--- a/src/modules/auth/service.js
+++ b/src/modules/auth/service.js
@@ -1,7 +1,139 @@
 const jwt = require('jsonwebtoken');
-
+const bcrypt = require('bcryptjs');
+const { randomUUID, createHash } = require('crypto');
+const { prisma } = require('../../utils/db');
 const { config } = require('../../config/env');
+const { sendSMS } = require('../rides/service');
+
 const SECRET = config.JWT_SECRET;
+const ACCESS_TTL = '15m';
+const REFRESH_TTL = '24h';
+const BCRYPT_ROUNDS = 12;
+
+const otpStore = new Map();
+
+async function hashPassword(password) {
+  return bcrypt.hash(password, BCRYPT_ROUNDS);
+}
+
+async function verifyPassword(password, hash) {
+  return bcrypt.compare(password, hash);
+}
+
+function issueAccessToken({ id, role }) {
+  if (!id || !role) throw new Error('id and role required');
+  return jwt.sign({ sub: id, role, type: 'access' }, SECRET, {
+    expiresIn: ACCESS_TTL,
+  });
+}
+
+function issueRefreshToken({ id }) {
+  const jti = randomUUID();
+  const token = jwt.sign({ sub: id, jti, type: 'refresh' }, SECRET, {
+    expiresIn: REFRESH_TTL,
+  });
+  return { token, jti };
+}
+
+async function createSession(userId, token) {
+  const payload = jwt.decode(token);
+  const hash = createHash('sha256').update(token).digest('hex');
+  return prisma.session.create({
+    data: {
+      id: payload.jti,
+      userId,
+      tokenHash: hash,
+      expiresAt: new Date(payload.exp * 1000),
+      revokedAt: null,
+    },
+  });
+}
+
+async function revokeSession(id) {
+  return prisma.session.update({
+    where: { id },
+    data: { revokedAt: new Date() },
+  });
+}
+
+async function findValidSession(token) {
+  let payload;
+  try {
+    payload = jwt.verify(token, SECRET);
+  } catch (e) {
+    return null;
+  }
+  if (payload.type !== 'refresh') return null;
+  const hash = createHash('sha256').update(token).digest('hex');
+  const session = await prisma.session.findUnique({
+    where: { id: payload.jti },
+  });
+  if (!session || session.tokenHash !== hash) return null;
+  if (session.revokedAt) return null;
+  if (session.expiresAt < new Date()) return null;
+  return { payload, session };
+}
+
+async function issueTokens(user) {
+  const accessToken = issueAccessToken(user);
+  const { token: refreshToken } = issueRefreshToken(user);
+  await createSession(user.id, refreshToken);
+  return { accessToken, refreshToken };
+}
+
+async function registerUser({ email, phone, password, role }) {
+  const existing = await prisma.user.findUnique({ where: { email } });
+  if (existing) throw new Error('email exists');
+  const passwordHash = await hashPassword(password);
+  const user = await prisma.user.create({
+    data: { email, phone, passwordHash, role },
+  });
+  return issueTokens(user);
+}
+
+async function sendOTP(user) {
+  const code = Math.floor(100000 + Math.random() * 900000).toString();
+  const codeHash = await hashPassword(code);
+  otpStore.set(user.email, { codeHash, expires: Date.now() + 10 * 60 * 1000 });
+  if (user.phone) {
+    await sendSMS(user.phone, `Your login code is ${code}`);
+  }
+}
+
+async function loginUser({ email, password, otp }) {
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) throw new Error('invalid');
+  if (password && (await verifyPassword(password, user.passwordHash))) {
+    return issueTokens(user);
+  }
+  const entry = otpStore.get(email);
+  if (
+    otp &&
+    entry &&
+    entry.expires > Date.now() &&
+    (await verifyPassword(otp, entry.codeHash))
+  ) {
+    otpStore.delete(email);
+    return issueTokens(user);
+  }
+  await sendOTP(user);
+  throw new Error('otp');
+}
+
+async function refreshTokens(token) {
+  const data = await findValidSession(token);
+  if (!data) throw new Error('invalid');
+  await revokeSession(data.payload.jti);
+  const user = await prisma.user.findUnique({
+    where: { id: data.payload.sub },
+  });
+  return issueTokens(user);
+}
+
+async function logout(token) {
+  const data = await findValidSession(token);
+  if (data) await revokeSession(data.payload.jti);
+}
 
 function authenticate(req, res, next) {
   const authHeader = req.header('authorization');
@@ -11,21 +143,32 @@ function authenticate(req, res, next) {
   const token = authHeader.replace(/^Bearer\s+/i, '');
   try {
     const payload = jwt.verify(token, SECRET);
-    if (!payload.id || !['patient', 'driver'].includes(payload.role)) {
-      throw new Error('invalid token');
-    }
-    req.user = { id: payload.id, role: payload.role };
+    if (payload.type !== 'access') throw new Error('invalid token');
+    req.user = { id: payload.sub, role: payload.role };
     return next();
   } catch (err) {
     return res.status(401).json({ error: 'invalid token' });
   }
 }
 
-function issueToken({ id, role }) {
-  if (!id || !['patient', 'driver'].includes(role)) {
-    throw new Error('id and valid role required');
-  }
-  return jwt.sign({ id, role }, SECRET, { expiresIn: '1h' });
+function authorize(...roles) {
+  return (req, res, next) => {
+    if (!req.user) return res.status(401).json({ error: 'unauthenticated' });
+    if (!roles.includes(req.user.role))
+      return res.status(403).json({ error: 'forbidden' });
+    next();
+  };
 }
 
-module.exports = { authenticate, issueToken };
+module.exports = {
+  authenticate,
+  authorize,
+  issueAccessToken,
+  issueToken: issueAccessToken,
+  registerUser,
+  loginUser,
+  refreshTokens,
+  logout,
+  // Exported for tests
+  _otpStore: otpStore,
+};


### PR DESCRIPTION
## Summary
- add User and Session models to Prisma schema
- expand Prisma mock for users and sessions
- build auth service with bcrypt, JWT access/refresh, OTP login
- expose /auth routes for register, login, token refresh and logout
- add comprehensive auth flow tests
- wire auth router into app
- include bcryptjs dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c589e12a88326a432602c1764879b