### PR TITLE
Harden Stripe webhook

### DIFF
--- a/__mocks__/@prisma/client.js
+++ b/__mocks__/@prisma/client.js
@@ -3,6 +3,7 @@ const insuranceDocs = [];
 const auditLogs = [];
 const users = [];
 const sessions = [];
+const webhookEvents = [];
 
 class PrismaClient {
   constructor() {
@@ -110,6 +111,20 @@ class PrismaClient {
         return session;
       },
     };
+
+    this.webhookEvent = {
+      findUnique: async ({ where }) => {
+        return webhookEvents.find((e) => e.id === where.id) || null;
+      },
+      upsert: async ({ where, create }) => {
+        let event = webhookEvents.find((e) => e.id === where.id);
+        if (!event) {
+          event = { id: where.id, ...create };
+          webhookEvents.push(event);
+        }
+        return event;
+      },
+    };
     this.$queryRaw = async () => [{ '?column?': 1 }];
     this.$use = () => {};
   }
@@ -121,4 +136,5 @@ module.exports = {
   __insuranceDocs: insuranceDocs,
   __users: users,
   __sessions: sessions,
+  __webhookEvents: webhookEvents,
 };

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -88,3 +88,8 @@ model Session {
   expiresAt DateTime @db.Timestamptz
   revokedAt DateTime? @db.Timestamptz
 }
+
+model WebhookEvent {
+  id        String   @id
+  createdAt DateTime @default(now()) @db.Timestamptz
+}


### PR DESCRIPTION
## Summary
- enforce Stripe webhook livemode checks and event idempotency
- track processed Stripe events in new `WebhookEvent` table
- test Stripe webhook logic with mocked payloads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ddf76c0148326a96718919e5daf78