### PR TITLE
Add server shutdown handlers

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -1,10 +1,2 @@
 #!/usr/bin/env node
-const { config } = require('../src/config/env');
-const { server, scheduleReminders } = require('../src/app');
-const { getLogger } = require('../src/utils/logger');
-
-const logger = getLogger(__filename);
-const port = config.PORT || 3000;
-
-scheduleReminders();
-server.listen(port, () => logger.info(`Server running on port ${port}`));
+require('../src/server');

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,40 @@
+const { config } = require('./config/env');
+const { server, prisma, scheduleReminders } = require('./app');
+const { getLogger } = require('./utils/logger');
+
+const log = getLogger(__filename);
+const port = config.PORT || 3000;
+
+function shutdown() {
+  log.info('🛑 shutting down');
+  // stop accepting new requests and close db
+  server.close(() => {
+    prisma.$disconnect().finally(() => {
+      process.exit(1);
+    });
+  });
+}
+
+process.on('unhandledRejection', (err) => {
+  log.fatal({ err }, 'Unhandled Rejection');
+  shutdown();
+});
+
+process.on('uncaughtException', (err) => {
+  log.fatal({ err }, 'Uncaught Exception');
+  shutdown();
+});
+
+function start() {
+  try {
+    scheduleReminders();
+    server.listen(port, () => log.info(`Server running on port ${port}`));
+  } catch (err) {
+    log.fatal({ err }, 'Failed to start server');
+    shutdown();
+  }
+}
+
+start();
+
+module.exports = { start, shutdown };


### PR DESCRIPTION
## Summary
- run web server through new src/server.js
- log fatal errors on unhandled rejections/exceptions
- cleanly close HTTP and DB connections before exiting

## Testing
- `npm test` *(fails: pgcrypto extension error)*

------
https://chatgpt.com/codex/tasks/task_e_684df27cc7bc83268dce9f09166828d5