### PR TITLE
Improve CI quality gates

### DIFF
--- a/.github/scripts/coverage-gate.sh
+++ b/.github/scripts/coverage-gate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-THRESHOLD=80
+THRESHOLD=85
 LINES=$(node - <<'JS'
 const fs=require('fs');
 const data=JSON.parse(fs.readFileSync('coverage/coverage-summary.json'));

--- a/.github/scripts/npm-audit-gate.js
+++ b/.github/scripts/npm-audit-gate.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+
+let data = '';
+process.stdin.on('data', chunk => data += chunk);
+process.stdin.on('end', () => {
+  const report = JSON.parse(data || '{}');
+  const meta = report.metadata && report.metadata.vulnerabilities || {};
+  const high = meta.high || 0;
+  const critical = meta.critical || 0;
+  if (high > 0 || critical > 0) {
+    console.error(`\u274c npm audit found ${high} high and ${critical} critical vulnerabilities`);
+    process.exit(1);
+  }
+  console.log('\u2705 No high or critical vulnerabilities');
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,20 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
+      - name: Security audit
+        run: npm audit --production --json | node .github/scripts/npm-audit-gate.js
       - name: Create chario database
         run: psql postgresql://chario:chario@localhost:5432/postgres -c "CREATE DATABASE chario;"
       - run: npx markdown-lint docs/**/*.md
       - run: npx prisma migrate deploy
-      - run: npm run test:coverage
+      - name: Run tests with coverage
+        run: npm run test:coverage -- --coverageThreshold='{"global":{"branches":80,"functions":85,"lines":85,"statements":85}}'
       - run: bash .github/scripts/coverage-gate.sh
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage/lcov.info
+          fail_ci_if_error: true
       - uses: github/codeql-action/analyze@v3
       - name: TruffleHog scan
         if: github.event_name == 'push'


### PR DESCRIPTION
## Summary
- enforce test coverage minimums and pass coverage data to Codecov
- add npm audit gating for high and critical vulnerabilities
- raise local coverage gate to 85%

## Testing
- `node .github/scripts/npm-audit-gate.js < <(npm audit --production --json)`
- `bash .github/scripts/coverage-gate.sh` *(fails: cannot find coverage summary)*

------
https://chatgpt.com/codex/tasks/task_e_684e03e6f45083269c09ce3d4c5b0b8a