### PR TITLE
Improve Pino logging

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,8 +2,7 @@ const express = require('express');
 const http = require('http');
 const { Server } = require('socket.io');
 const { prisma } = require('./utils/db');
-const pinoHttp = require('pino-http');
-const { getLogger } = require('./utils/logger');
+const { getLogger, httpLogger } = require('./utils/logger');
 const { randomUUID, createHash } = require('crypto');
 const { observeRequest } = require('./utils/metrics');
 const client = require('prom-client');
@@ -34,9 +33,7 @@ const {
 
 const app = express();
 client.collectDefaultMetrics();
-const httpLogger = pinoHttp({
-  genReqId: (req) => req.headers['x-correlation-id'] || randomUUID(),
-});
+const httpLoggerMiddleware = httpLogger;
 const log = getLogger(__filename);
 function requireTLS(req, res, next) {
   if (config.NODE_ENV === 'test') {
@@ -48,7 +45,7 @@ function requireTLS(req, res, next) {
   return res.status(426).send('HTTPS required');
 }
 app.use(requireTLS);
-app.use(httpLogger);
+app.use(httpLoggerMiddleware);
 app.use((req, res, next) => {
   res.setHeader('x-correlation-id', req.id);
   next();

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,4 +1,6 @@
 const pino = require('pino');
+const pinoHttp = require('pino-http');
+const { randomUUID } = require('crypto');
 const path = require('path');
 
 const transport =
@@ -17,6 +19,35 @@ const root = pino(
   transport,
 );
 
+const httpLogger = pinoHttp({
+  logger: root,
+  level: 'info',
+  genReqId: (req) => req.headers['x-correlation-id'] || randomUUID(),
+  serializers: {
+    req(req) {
+      const result = pino.stdSerializers.req(req);
+      if (req.body && typeof req.body === 'object') {
+        const { phone, address, token, ...rest } = req.body;
+        result.body = rest;
+      }
+      return result;
+    },
+    res(res) {
+      const result = pino.stdSerializers.res(res);
+      if (result && result.headers) {
+        const { 'set-cookie': _discard, ...headers } = result.headers;
+        result.headers = headers;
+      }
+      return result;
+    },
+  },
+  customLogLevel(res, err) {
+    if (err || res.statusCode >= 500) return 'error';
+    if (res.statusCode >= 400) return 'warn';
+    return 'info';
+  },
+});
+
 function getLogger(filename) {
   const modulePath = path
     .relative(path.join(__dirname, '..'), filename)
@@ -24,4 +55,4 @@ function getLogger(filename) {
   return root.child({ module: modulePath });
 }
 
-module.exports = { logger: root, getLogger };
+module.exports = { logger: root, getLogger, httpLogger };


### PR DESCRIPTION
## Summary
- sanitize request/response logs to remove phone, address and token
- ignore `set-cookie` headers in logs
- expose configured http logger and use it in app
- downgrade 4xx responses to WARN level

## Testing
- `npm test --silent` *(fails: pgcrypto extension)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684e085fab28832686a169db5b90b26a