### PR TITLE
Ensure pgcrypto tests run with postgres container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,20 +8,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      DATABASE_URL: 'postgresql://chario:chario@localhost:5432/chario_test'
-    services:
-      postgres:
-        image: postgres:15-alpine
-        env:
-          POSTGRES_USER: chario
-          POSTGRES_PASSWORD: chario
-          POSTGRES_DB: chario_test
-        ports: ['5432:5432']
-        options: >-
-          --health-cmd="pg_isready -U chario"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
+      DATABASE_URL: 'postgresql://testuser:testpass@localhost:5432/testdb'
     steps:
       - uses: actions/checkout@v4
       - uses: github/codeql-action/init@v3
@@ -30,16 +17,26 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - run: docker-compose -f docker-compose.test.yml up -d db
+      - name: Wait for DB
+        run: |
+          for i in {1..10}; do
+            if docker-compose -f docker-compose.test.yml exec -T db pg_isready -U testuser; then
+              exit 0
+            fi
+            sleep 3
+          done
+          docker-compose -f docker-compose.test.yml logs db
+          exit 1
       - run: npm ci
       - name: Security audit
         run: npm audit --production --json | node .github/scripts/npm-audit-gate.js
-      - name: Create chario database
-        run: psql postgresql://chario:chario@localhost:5432/postgres -c "CREATE DATABASE chario;"
       - run: npx markdown-lint docs/**/*.md
       - run: npx prisma migrate deploy
       - name: Run tests with coverage
         run: npm run test:coverage -- --coverageThreshold='{"global":{"branches":80,"functions":85,"lines":85,"statements":85}}'
       - run: bash .github/scripts/coverage-gate.sh
+      - run: docker-compose -f docker-compose.test.yml down
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: testdb
+      POSTGRES_USER: testuser
+      POSTGRES_PASSWORD: testpass
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U testuser"]
+      interval: 3s
+      timeout: 5s
+      retries: 10

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "setupFiles": [
       "<rootDir>/tests/jest.setup.js"
     ],
+    "globalSetup": "<rootDir>/tests/globalSetup.js",
     "moduleNameMapper": {
       "\\.css$": "identity-obj-proxy"
     },

--- a/tests/globalSetup.js
+++ b/tests/globalSetup.js
@@ -1,0 +1,7 @@
+const { Pool } = require('pg');
+
+module.exports = async () => {
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  await pool.query('CREATE EXTENSION IF NOT EXISTS pgcrypto');
+  await pool.end();
+};

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -3,7 +3,7 @@ nock('https://api.stripe.com').post(/.*/).reply(200, { success: true });
 
 process.env = {
   ...process.env,
-  DATABASE_URL: 'postgresql://chario:chario@localhost:5432/chario_test',
+  DATABASE_URL: 'postgresql://testuser:testpass@localhost:5432/testdb',
   JWT_SECRET: 'a'.repeat(32),
   STRIPE_KEY: 'sk_test_123',
   TWILIO_SID: 'ACxxx',


### PR DESCRIPTION
## Summary
- add docker compose file to start Postgres for testing
- create a global setup script that installs pgcrypto
- update test DATABASE_URL and hook global setup
- update CI workflow to use docker compose

## Testing
- `npm ci` *(fails: could not resolve dependencies)*
- `docker compose -f docker-compose.test.yml up -d db` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e100b1fe88326b472d94064cacc8d