### PR TITLE
Fix CI postgres startup race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
           --health-cmd="pg_isready -U testuser" --health-interval=10s --health-timeout=5s --health-retries=5
     env:
       DATABASE_URL: 'postgresql://testuser:testpass@localhost:5432/testdb'
+      PGHOST: localhost
+      PGPORT: '5432'
+      PGUSER: testuser
+      PGPASSWORD: testpass
+      PGDATABASE: testdb
     steps:
       - uses: actions/checkout@v4
       - uses: github/codeql-action/init@v3
@@ -39,6 +44,13 @@ jobs:
           fi
       - name: Prisma binary targets
         run: echo "PRISMA_CLI_BINARY_TARGETS=native" >> $GITHUB_ENV
+      - name: Wait for Postgres to be ready
+        run: |
+          for i in {1..15}; do
+            pg_isready -h localhost -p 5432 -U testuser && break
+            echo "Postgres not ready yet... ($i/15)"
+            sleep 2
+          done
       - run: npm ci
       - run: npx prisma generate
       - name: Security audit

--- a/tests/globalSetup.js
+++ b/tests/globalSetup.js
@@ -2,6 +2,15 @@ const { Pool } = require('pg');
 
 module.exports = async () => {
   const pool = new Pool({ connectionString: process.env.DATABASE_URL });
-  await pool.query('CREATE EXTENSION IF NOT EXISTS pgcrypto');
+  for (let i = 0; i < 5; i += 1) {
+    try {
+      await pool.query('CREATE EXTENSION IF NOT EXISTS pgcrypto');
+      break;
+    } catch (err) {
+      if (i === 4) throw err;
+      console.log('Waiting for postgres...');
+      await new Promise((res) => setTimeout(res, 2000));
+    }
+  }
   await pool.end();
 };


### PR DESCRIPTION
## Summary
- wait for Postgres service before tests
- retry DB init in jest global setup
- export Postgres env vars for PR jobs

## Testing
- `npm ci --legacy-peer-deps` *(failed: network block for binaries.prisma.sh but completed with warnings)*
- `npm test` *(failed: Jest global setup could not connect to Postgres)*

------
https://chatgpt.com/codex/tasks/task_e_684e156db6208326a803039d82e2b049