### PR TITLE
Improve CI postgres readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,29 +44,18 @@ jobs:
           fi
       - name: Prisma binary targets
         run: echo "PRISMA_CLI_BINARY_TARGETS=native" >> $GITHUB_ENV
-      - name: Wait for Postgres to be ready
-        run: |
-          for i in {1..30}; do
-            pg_isready -h localhost -p 5432 -U testuser && break
-            echo "Waiting for Postgres..."
-            sleep 2
-          done
-      - name: Wait for Postgres with psql
-        run: |
-          until PGPASSWORD=testpass psql -h localhost -U testuser -c '\q'; do
-            echo "Waiting for Postgres to accept connections..."
-            sleep 2
-          done
+      - name: Wait for Postgres
+        run: ./scripts/wait-for-postgres.sh localhost testuser
       - run: npm ci
+      - run: npx prisma generate
+      - run: npx prisma migrate deploy
       - name: Run Lint
         run: npm run lint
       - name: Run Tests
         run: npm test
-      - run: npx prisma generate
       - name: Security audit
         run: npm audit --production --json | node .github/scripts/npm-audit-gate.js
       - run: npx markdown-lint docs/**/*.md
-      - run: npx prisma migrate deploy
       - name: Run tests with coverage
         run: npm run test:coverage -- --coverageThreshold='{"global":{"branches":80,"functions":85,"lines":85,"statements":85}}'
       - run: bash .github/scripts/coverage-gate.sh

--- a/scripts/wait-for-postgres.sh
+++ b/scripts/wait-for-postgres.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+HOST=${1:-localhost}
+USER=${2:-$PGUSER}
+for i in {1..30}; do
+  if pg_isready -h "$HOST" -U "$USER"; then
+    echo "Postgres is ready"
+    exit 0
+  fi
+  echo "Waiting for postgres..."
+  sleep 2
+done
+
+echo "Failed to connect to Postgres" >&2
+docker-compose ps || true
+docker logs postgres || true
+exit 1


### PR DESCRIPTION
## Summary
- wait for Postgres using a helper script
- run Prisma migrations/generate before tests
- add helper script to print logs when DB isn't ready

## Testing
- `npm ci --legacy-peer-deps`
- `npx prisma generate` *(fails: Failed to fetch the engine file)*
- `npx prisma migrate deploy` *(fails: Failed to fetch the engine file)*
- `npm test` *(fails: Jest globalSetup error)*

------
https://chatgpt.com/codex/tasks/task_e_684e25f9f024832682a6f949398ba0d1