### PR TITLE
Rename CHARIO to OBVIO

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Run OWASP Dependency Check
         uses: dependency-check/Dependency-Check_Action@1.1.0
         with:
-          project: 'CHARIO'
+          project: 'OBVIO'
           path: '.'
           format: 'HTML'
       - name: Upload report

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,19 +12,19 @@ jobs:
       postgres:
         image: postgres:15-alpine
         env:
-          POSTGRES_USER: chario
-          POSTGRES_PASSWORD: chario
-          POSTGRES_DB: chario_test
+          POSTGRES_USER: obvio
+          POSTGRES_PASSWORD: obvio
+          POSTGRES_DB: obvio_test
         ports: ['5432:5432']
         options: >-
-          --health-cmd="pg_isready -U chario" --health-interval=10s --health-timeout=5s --health-retries=5
+          --health-cmd="pg_isready -U obvio" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
       - uses: actions/checkout@v4
       - name: Build image
-        run: docker build -t chario .
+        run: docker build -t obvio .
       - name: Run container
         run: |
-          docker run -d -p 3000:3000 --name chario_app chario
+          docker run -d -p 3000:3000 --name obvio_app obvio
       - name: Wait for health
         run: |
           for i in {1..30}; do
@@ -34,7 +34,7 @@ jobs:
             sleep 1
           done
           echo "service failed to start" >&2
-          docker logs chario_app
+          docker logs obvio_app
           exit 1
       - name: Smoke /health & /metrics
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to CHARIO
+# Contributing to OBVIO
 
 Thank you for helping improve this project! The following guidelines keep the repository consistent.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CHARIO
+# OBVIO
 
 ![Code Style: Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)
 
@@ -7,7 +7,7 @@ Simplified ride scheduling for non-emergency medical transport.
 ## Quick Start
 
 ```bash
-git clone https://github.com/yourname/CHARIO && cd CHARIO
+git clone https://github.com/yourname/OBVIO && cd OBVIO
 cp .env.example .env              # fill secrets
 docker-compose up -d              # start postgres, redis and minio
 npm ci
@@ -30,7 +30,7 @@ graph TD
 ## Getting Started
 
 ```bash
-git clone https://github.com/yourname/CHARIO && cd CHARIO
+git clone https://github.com/yourname/OBVIO && cd OBVIO
 cp .env.example .env              # fill secrets
 # PATIENT_DATA_KEY is required for pgcrypto encryption
 npm ci && npx prisma migrate dev  # creates DB
@@ -52,12 +52,12 @@ local Postgres instance:
    ```
 3. Launch the server pointing `DATABASE_URL` at the new database:
    ```bash
-   DATABASE_URL=postgresql://localhost:5433/chario_local npm run dev
+   DATABASE_URL=postgresql://localhost:5433/obvio_local npm run dev
    ```
 
 ## Replit Deploy
 
-1. [Fork this repo](https://github.com/yourname/CHARIO) and import it into [Replit](https://replit.com).
+1. [Fork this repo](https://github.com/yourname/OBVIO) and import it into [Replit](https://replit.com).
 2. Add environment variables found in `.env.example` using Replit Secrets or run:
    ```bash
    ./scripts/sync-secrets.sh replit

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # System Architecture
 
-This document provides an overview of the CHARIO service including request flows, database layout and example API payloads.
+This document provides an overview of the OBVIO service including request flows, database layout and example API payloads.
 
 ## Sequence diagram
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -64,5 +64,5 @@ protected with basic authentication. The container exposes port `9100` for
 Prometheus scraping.
 
 The repository includes a Grafana dashboard definition at
-`ops/grafana/chario_dashboard.json`. Operations teams should import this file
+`ops/observability/obvio_dashboard.json`. Operations teams should import this file
 using Terraform or the Grafana HTTP API so metrics show up automatically.

--- a/fly.toml
+++ b/fly.toml
@@ -1,4 +1,4 @@
-app = "chario"
+app = "obvio"
 kill_signal = "SIGTERM"
 kill_timeout = 30
 [build]

--- a/ops/api.yaml
+++ b/ops/api.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: CHARIO API
+  title: OBVIO API
   version: '1.0'
 servers:
   - url: http://localhost:3000

--- a/ops/observability/obvio_dashboard.json
+++ b/ops/observability/obvio_dashboard.json
@@ -54,8 +54,8 @@
   "refresh": "30s",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": ["chario"],
+  "tags": ["obvio"],
   "time": { "from": "now-6h", "to": "now" },
-  "title": "CHARIO Overview",
+  "title": "OBVIO Overview",
   "version": 1
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "chario",
+  "name": "obvio",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "chario",
+      "name": "obvio",
       "version": "1.0.0",
       "hasInstallScript": true,
       "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "chario",
+  "name": "obvio",
   "version": "1.0.0",
   "description": "medical rides, simplified. Uber-style app for non-emergency transport: patients schedule trips a week ahead, insurance is auto-verified or card-paid, drivers get guaranteed pickups, and everyone tracks status in real time. Affordable, transparent, and built for healthcare logistics.",
   "main": "index.js",

--- a/prisma/migrations/0001_init/migration.sql
+++ b/prisma/migrations/0001_init/migration.sql
@@ -1,4 +1,4 @@
--- SQL schema for CHARIO database
+-- SQL schema for OBVIO database
 -- This file creates patients, drivers, rides, and payments tables with UUID primary keys
 -- and appropriate foreign key relationships. It also includes indexes for ride pickup time
 -- and status.

--- a/schema.sql
+++ b/schema.sql
@@ -1,4 +1,4 @@
--- SQL schema for CHARIO database
+-- SQL schema for OBVIO database
 -- This file creates patients, drivers, rides, and payments tables with UUID primary keys
 -- and appropriate foreign key relationships. It also includes indexes for ride pickup time
 -- and status.

--- a/scripts/local-postgres.sh
+++ b/scripts/local-postgres.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 # Start single-user Postgres on a random port
 pg_ctl -D .pgdata -o "-F -p 5433" -l logfile start
-createdb -p 5433 chario_local || true
+createdb -p 5433 obvio_local || true


### PR DESCRIPTION
## Summary
- rename project references from CHARIO to OBVIO
- rename Grafana dashboard file

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find module 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_685153f49e6883268e2d0bb7cde1097d